### PR TITLE
Removed unused device in SCEP controller test

### DIFF
--- a/test/controllers/scep_controller_test.rb
+++ b/test/controllers/scep_controller_test.rb
@@ -17,8 +17,6 @@ class ScepControllerTest < ActionController::TestCase
   end
   
   test 'certificate generation' do
-    
-    device = devices(:james_macbook)
 
     key = OpenSSL::PKey::RSA.new 1024
     


### PR DESCRIPTION
In the SCEP test device is not used.
